### PR TITLE
Fix Erlang 24 Warnings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [ {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.4"}}}
        , {gen_coap, {git, "https://github.com/emqx/gen_coap", {tag, "v0.3.2"}}}
-       , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib", {tag, "0.2.0"}}}
+       , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib", {tag, "0.2.1"}}}
        ]}.
 
 {dialyzer, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {deps, [ {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.4"}}}
        , {gen_coap, {git, "https://github.com/emqx/gen_coap", {tag, "v0.3.2"}}}
+       , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib", {tag, "0.1.0"}}}
        ]}.
 
 {dialyzer, [

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,6 @@
-{deps, [{esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.4"}}}]}.
+{deps, [ {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.4"}}}
+       , {gen_coap, {git, "https://github.com/emqx/gen_coap", {tag, "v0.3.2"}}}
+       ]}.
 
 {dialyzer, [
   {warnings, [unmatched_returns, error_handling, race_conditions]},

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {deps, [ {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.4"}}}
        , {gen_coap, {git, "https://github.com/emqx/gen_coap", {tag, "v0.3.2"}}}
-       , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib", {tag, "0.1.0"}}}
+       , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib", {tag, "0.2.0"}}}
        ]}.
 
 {dialyzer, [

--- a/src/client/lwm2m_coap_client.erl
+++ b/src/client/lwm2m_coap_client.erl
@@ -91,15 +91,9 @@ ack(Channel, Message) ->
 
 resolve_uri(Uri) ->
     {ok, Parsed} = emqx_http_lib:uri_parse(Uri),
-    #{scheme := Scheme, host := Host, path := Path} = Parsed,
+    #{scheme := Scheme, host := Host, path := Path, port := PortNo} = Parsed,
+    Scheme =/= coap andalso Scheme =/= coaps andalso error({unexpected_scheme, Scheme}), %% assert
     Query = maps:get(query, Parsed, ""),
-    DefaultPortNo =
-        case Scheme of
-            coap -> ?DEFAULT_COAP_PORT;
-            coaps -> ?DEFAULT_COAPS_PORT
-        end,
-    PortNo = maps:get(port, Parsed, DefaultPortNo),
-
     {ok, PeerIP} = inet:getaddr(Host, inet),
     {Scheme, {PeerIP, PortNo}, split_path(Path), split_query(Query)}.
 

--- a/src/client/lwm2m_coap_client.erl
+++ b/src/client/lwm2m_coap_client.erl
@@ -90,8 +90,16 @@ ack(Channel, Message) ->
 
 
 resolve_uri(Uri) ->
-    {ok, {Scheme, _UserInfo, Host, PortNo, Path, Query}} =
-        http_uri:parse(Uri, [{scheme_defaults, [{coap, ?DEFAULT_COAP_PORT}, {coaps, ?DEFAULT_COAPS_PORT}]}]),
+    #{scheme := SchemeStr, host := Host, path := Path} = Parsed = uri_string:parse(Uri),
+    Scheme = erlang:list_to_atom(SchemeStr),
+    Query = maps:get(query, Parsed, ""),
+    DefaultPortNo =
+        case Scheme of
+            coap -> ?DEFAULT_COAP_PORT;
+            coaps -> ?DEFAULT_COAPS_PORT
+        end,
+    PortNo = maps:get(port, Parsed, DefaultPortNo),
+
     {ok, PeerIP} = inet:getaddr(Host, inet),
     {Scheme, {PeerIP, PortNo}, split_path(Path), split_query(Query)}.
 
@@ -100,7 +108,8 @@ split_path([$/]) -> [];
 split_path([$/ | Path]) -> split_segments(Path, $/, []).
 
 split_query([]) -> [];
-split_query([$? | Path]) -> split_segments(Path, $&, []).
+split_query([$? | Path]) -> split_segments(Path, $&, []);
+split_query(Path) -> split_segments(Path, $&, []).
 
 split_segments(Path, Char, Acc) ->
     case string:rchr(Path, Char) of
@@ -112,7 +121,7 @@ split_segments(Path, Char, Acc) ->
     end.
 
 make_segment(Seg) ->
-    list_to_binary(http_uri:decode(Seg)).
+    list_to_binary(uri_string:percent_decode(Seg)).
 
 channel_apply(coap, ChId, Fun) ->
     {ok, Sock} = lwm2m_coap_udp_socket:start_link(),

--- a/src/client/lwm2m_coap_client.erl
+++ b/src/client/lwm2m_coap_client.erl
@@ -90,8 +90,8 @@ ack(Channel, Message) ->
 
 
 resolve_uri(Uri) ->
-    #{scheme := SchemeStr, host := Host, path := Path} = Parsed = uri_string:parse(Uri),
-    Scheme = erlang:list_to_atom(SchemeStr),
+    {ok, Parsed} = emqx_http_lib:uri_parse(Uri),
+    #{scheme := Scheme, host := Host, path := Path} = Parsed,
     Query = maps:get(query, Parsed, ""),
     DefaultPortNo =
         case Scheme of
@@ -121,7 +121,7 @@ split_segments(Path, Char, Acc) ->
     end.
 
 make_segment(Seg) ->
-    list_to_binary(uri_string:percent_decode(Seg)).
+    list_to_binary(emqx_http_lib:uri_decode(Seg)).
 
 channel_apply(coap, ChId, Fun) ->
     {ok, Sock} = lwm2m_coap_udp_socket:start_link(),

--- a/src/coap_core_link.erl
+++ b/src/coap_core_link.erl
@@ -49,9 +49,40 @@ encode_link_uri(absolute, UriList) -> "</"++join_uri(UriList)++">";
 encode_link_uri(rootless, UriList) -> "<"++join_uri(UriList)++">".
 
 join_uri([Seg]) ->
-    http_uri:encode(binary_to_list(Seg));
+    http_uri_encode(binary_to_list(Seg));
 join_uri([Seg|Uri]) ->
-    http_uri:encode(binary_to_list(Seg))++"/"++join_uri(Uri).
+    http_uri_encode(binary_to_list(Seg))++"/"++join_uri(Uri).
+
+%% The following functions are forked from http_uri module
+%% reserved/1, http_uri_encode/1, uri_encode/1, uri_encode_binary/1
+
+reserved() ->
+    sets:from_list([$;, $:, $@, $&, $=, $+, $,, $/, $?,
+                    $#, $[, $], $<, $>, $\", ${, $}, $|, %"
+                    $\\, $', $^, $%, $ ]).
+
+http_uri_encode(URI) when is_list(URI) ->
+    Reserved = reserved(),
+    lists:append([uri_encode(Char, Reserved) || Char <- URI]);
+http_uri_encode(URI) when is_binary(URI) ->
+    Reserved = reserved(),
+    << <<(uri_encode_binary(Char, Reserved))/binary>> || <<Char>> <= URI >>.
+
+uri_encode(Char, Reserved) ->
+    case sets:is_element(Char, Reserved) of
+        true ->
+            [ $% | http_util:integer_to_hexlist(Char)];
+        false ->
+            [Char]
+    end.
+
+uri_encode_binary(Char, Reserved) ->
+    case sets:is_element(Char, Reserved) of
+        true ->
+            << $%, (integer_to_binary(Char, 16))/binary >>;
+        false ->
+            <<Char>>
+    end.
 
 encode_link_param({_Any, undefined}) -> undefined;
 encode_link_param({ct, Value}) -> ";ct=" ++ content_type_to_int(Value);

--- a/src/coap_core_link.erl
+++ b/src/coap_core_link.erl
@@ -49,40 +49,9 @@ encode_link_uri(absolute, UriList) -> "</"++join_uri(UriList)++">";
 encode_link_uri(rootless, UriList) -> "<"++join_uri(UriList)++">".
 
 join_uri([Seg]) ->
-    http_uri_encode(binary_to_list(Seg));
+    emqx_http_lib:uri_encode(binary_to_list(Seg));
 join_uri([Seg|Uri]) ->
-    http_uri_encode(binary_to_list(Seg))++"/"++join_uri(Uri).
-
-%% The following functions are forked from http_uri module
-%% reserved/1, http_uri_encode/1, uri_encode/1, uri_encode_binary/1
-
-reserved() ->
-    sets:from_list([$;, $:, $@, $&, $=, $+, $,, $/, $?,
-                    $#, $[, $], $<, $>, $\", ${, $}, $|, %"
-                    $\\, $', $^, $%, $ ]).
-
-http_uri_encode(URI) when is_list(URI) ->
-    Reserved = reserved(),
-    lists:append([uri_encode(Char, Reserved) || Char <- URI]);
-http_uri_encode(URI) when is_binary(URI) ->
-    Reserved = reserved(),
-    << <<(uri_encode_binary(Char, Reserved))/binary>> || <<Char>> <= URI >>.
-
-uri_encode(Char, Reserved) ->
-    case sets:is_element(Char, Reserved) of
-        true ->
-            [ $% | http_util:integer_to_hexlist(Char)];
-        false ->
-            [Char]
-    end.
-
-uri_encode_binary(Char, Reserved) ->
-    case sets:is_element(Char, Reserved) of
-        true ->
-            << $%, (integer_to_binary(Char, 16))/binary >>;
-        false ->
-            <<Char>>
-    end.
+    emqx_http_lib:uri_encode(binary_to_list(Seg))++"/"++join_uri(Uri).
 
 encode_link_param({_Any, undefined}) -> undefined;
 encode_link_param({ct, Value}) -> ";ct=" ++ content_type_to_int(Value);

--- a/src/lwm2m_coap_responder.erl
+++ b/src/lwm2m_coap_responder.erl
@@ -44,7 +44,7 @@ stop(Pid, Reason) ->
     gen_server:cast(Pid, {stop, Reason}).
 
 notify(Uri, Resource) ->
-    case pg2:get_members({coap_observer, Uri}) of
+    case pg:get_members({coap_observer, Uri}) of
         {error, _} -> ok;
         List -> [gen_server:cast(Pid, Resource) || Pid <- List]
     end.
@@ -248,8 +248,7 @@ handle_observe(ChId, Request=#coap_message{options=Options}, Content=#coap_conte
     case invoke_callback(Module, coap_observe, [ChId, Prefix, requires_ack(Request), Content], Lwm2mState, Args) of
         {ok, Lwm2mState2} ->
             Uri = proplists:get_value(uri_path, Options, []),
-            pg2:create({coap_observer, Uri}),
-            ok = pg2:join({coap_observer, Uri}, self()),
+            ok = pg:join({coap_observer, Uri}, self()),
             return_resource(Request, Content, State#state{observer=Request, lwm2m_state=Lwm2mState2});
         {error, method_not_allowed, Lwm2mState2} ->
             % observe is not supported, fallback to standard get
@@ -275,12 +274,7 @@ cancel_observer(undefined, _State) ->
 cancel_observer(#coap_message{options=Options}, State=#state{module=Module, lwm2m_state=Lwm2mState, args=Args}) ->
     {ok, Lwm2mState2} = invoke_callback(Module, coap_unobserve, [], Lwm2mState, Args),
     Uri = proplists:get_value(uri_path, Options, []),
-    ok = pg2:leave({coap_observer, Uri}, self()),
-    % will the last observer to leave this group please turn out the lights
-    case pg2:get_members({coap_observer, Uri}) of
-        [] -> pg2:delete({coap_observer, Uri});
-        _Else -> ok
-    end,
+    ok = pg:leave({coap_observer, Uri}, self()),
     {ok, State#state{observer=undefined, lwm2m_state=Lwm2mState2}}.
 
 handle_post(ChId, Request, State=#state{prefix=Prefix, module=Module, lwm2m_state=Lwm2mState, args=Args}) ->


### PR DESCRIPTION
There're 3 major points for this pr:

### http_uri -> uri_string
`http_uri:decode` -> `emqx_http_lib:uri_decode`
`http_uri:encode` -> `emqx_http_lib:uri_encode`

### pg2 -> pg
https://erlang.org/doc/man/pg.html

> Groups are automatically created when any process joins, and are removed when all processes leave the group. Non-existing group is considered empty (containing no processes).

### make test
14 tests, 10 failures, 4 cancelled for both master and this pr after added gen_coap depend