### PR TITLE
fix(channel): fix funcation_clause for bad datagram

### DIFF
--- a/src/lwm2m_coap.appup.src
+++ b/src/lwm2m_coap.appup.src
@@ -1,11 +1,29 @@
 %% -*-: erlang -*-
-{"v1.1.2",
+{"1.1.4",
    [
+     {"1.1.3", [
+       {load_module, lwm2m_coap_channel, brutal_purge, soft_purge, []}
+     ]},
+     {"1.1.2", [
+       {load_module, coap_core_link, brutal_purge, soft_purge, []},
+       {load_module, lwm2m_coap_client, brutal_purge, soft_purge, []},
+       {load_module, lwm2m_coap_responder, brutal_purge, soft_purge, []},
+       {load_module, lwm2m_coap_channel, brutal_purge, soft_purge, []}
+     ]},
      {"0.3.0", [
        {load_module, lwm2m_coap_transport, brutal_purge, soft_purge, []}
      ]}
    ],
    [
+     {"1.1.3", [
+       {load_module, lwm2m_coap_channel, brutal_purge, soft_purge, []}
+     ]},
+     {"1.1.2", [
+       {load_module, coap_core_link, brutal_purge, soft_purge, []},
+       {load_module, lwm2m_coap_client, brutal_purge, soft_purge, []},
+       {load_module, lwm2m_coap_responder, brutal_purge, soft_purge, []},
+       {load_module, lwm2m_coap_channel, brutal_purge, soft_purge, []}
+     ]},
      {"0.3.0", [
        {load_module, lwm2m_coap_transport, brutal_purge, soft_purge, []}
      ]}

--- a/src/lwm2m_coap_channel.erl
+++ b/src/lwm2m_coap_channel.erl
@@ -237,7 +237,8 @@ handle_datagram(BinMessage= <<?VERSION:2, _T:2, TKL:4, _Code:8, MsgId:16, Token:
     end;
 
 % silently ignore other versions
-handle_datagram(<<Ver:2, _/bytes>>, State) when Ver /= ?VERSION ->
+handle_datagram(Unexpected, State) ->
+    logger:debug("Unexpected datagram data: ~p", [Unexpected]),
     {noreply, State, hibernate}.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
When an unknown message is received, a funcation_caluse is reported here which prints a very large number of crash logs.

BTW,  `<<Ver:2, _/bytes>>` CAN NOT MATCH any binary